### PR TITLE
fix: add Ninjutsu and Scouter to legal pages, fix SoundBloom typo

### DIFF
--- a/legal/privacy.html
+++ b/legal/privacy.html
@@ -61,7 +61,8 @@
 <main>
   <p>
     This Privacy Policy applies to all Bonsai… apps, including 
-    <strong>WordPath</strong>, <strong>SoundBloom</strong>, <strong>Buy or Goodbye</strong>, <strong>CodeRain</strong>, and 
+    <strong>WordPath</strong>, <strong>SonicBloom</strong>, <strong>Buy or Goodbye</strong>, <strong>CodeRain</strong>,
+    <strong>Ninjutsu</strong>, <strong>Scouter</strong>, and
     <strong>Tutti Fruttini Combinasion</strong>. By using these apps, you agree to the practices described below.
   </p>
 

--- a/legal/terms.html
+++ b/legal/terms.html
@@ -56,7 +56,7 @@
   </script>
   <header><h1>Terms of Service</h1></header>
   <main>
-    <p>These Terms of Service apply to all Bonsai … apps, including <strong>WordPath</strong>, <strong>SonicBloom</strong>, <strong>Buy or Goodbye</strong>, <strong>CodeRain</strong>, and <strong>Tutti Fruttini Combinasion</strong>.</p>
+    <p>These Terms of Service apply to all Bonsai … apps, including <strong>WordPath</strong>, <strong>SonicBloom</strong>, <strong>Buy or Goodbye</strong>, <strong>CodeRain</strong>, <strong>Ninjutsu</strong>, <strong>Scouter</strong>, and <strong>Tutti Fruttini Combinasion</strong>.</p>
     <h2>Use of Apps</h2>
     <p>Apps are for personal, non‑commercial use. You agree not to reverse engineer or redistribute them.</p>
     <h2>Disclaimer</h2>


### PR DESCRIPTION
## Summary
- `legal/privacy.html` — added Ninjutsu and Scouter to app list, fixed typo SoundBloom → SonicBloom
- `legal/terms.html` — added Ninjutsu and Scouter to app list

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)