### PR TITLE
Fix content bugs and extract nav init to shared component

### DIFF
--- a/apps/buyorgoodbye/about.html
+++ b/apps/buyorgoodbye/about.html
@@ -20,45 +20,15 @@
 </head>
 <body>
 
-<div id="nav-placeholder"></div>
-<script>
-  fetch("/components/nav.html")
-    .then(response => response.text())
-    .then(data => {
-      document.getElementById("nav-placeholder").innerHTML = data;
-
-      // Initialize mobile submenu toggling
-      const nav = document.querySelector('.bonsai-nav');
-      if (nav) {
-        nav.addEventListener('click', function(e) {
-          if (e.target.closest('.submenu')) return;
-          const li = e.target.closest('.has-submenu');
-          if (!li) return;
-          e.preventDefault();
-          nav.querySelectorAll('.has-submenu.open').forEach(item => {
-            if (item !== li) item.classList.remove('open');
-          });
-          const isOpening = !li.classList.contains('open');
-          li.classList.toggle('open');
-          if (isOpening && window.innerWidth <= 700) {
-            const submenu = li.querySelector('.submenu');
-            if (submenu) {
-              const rect = li.getBoundingClientRect();
-              submenu.style.top = rect.bottom + 'px';
-              submenu.style.left = rect.left + 'px';
-            }
-          }
-        });
-        document.addEventListener('click', function(e) {
-          if (!e.target.closest('.bonsai-nav')) {
-            nav.querySelectorAll('.has-submenu.open').forEach(item => {
-              item.classList.remove('open');
-            });
-          }
-        });
-      }
-    });
-</script>
+<div id="nav-placeholder"></div>  <script src="/components/nav-init.js"></script>
+  <script>
+    fetch("/components/nav.html")
+      .then(function(r) { return r.text(); })
+      .then(function(html) {
+        document.getElementById("nav-placeholder").innerHTML = html;
+        initBonsaiNav();
+      });
+  </script>
 
 
   <header>

--- a/apps/sonicbloom/about.html
+++ b/apps/sonicbloom/about.html
@@ -20,45 +20,15 @@
 </head>
 <body>
 
-<div id="nav-placeholder"></div>
-<script>
-  fetch("/components/nav.html")
-    .then(response => response.text())
-    .then(data => {
-      document.getElementById("nav-placeholder").innerHTML = data;
-
-      // Initialize mobile submenu toggling
-      const nav = document.querySelector('.bonsai-nav');
-      if (nav) {
-        nav.addEventListener('click', function(e) {
-          if (e.target.closest('.submenu')) return;
-          const li = e.target.closest('.has-submenu');
-          if (!li) return;
-          e.preventDefault();
-          nav.querySelectorAll('.has-submenu.open').forEach(item => {
-            if (item !== li) item.classList.remove('open');
-          });
-          const isOpening = !li.classList.contains('open');
-          li.classList.toggle('open');
-          if (isOpening && window.innerWidth <= 700) {
-            const submenu = li.querySelector('.submenu');
-            if (submenu) {
-              const rect = li.getBoundingClientRect();
-              submenu.style.top = rect.bottom + 'px';
-              submenu.style.left = rect.left + 'px';
-            }
-          }
-        });
-        document.addEventListener('click', function(e) {
-          if (!e.target.closest('.bonsai-nav')) {
-            nav.querySelectorAll('.has-submenu.open').forEach(item => {
-              item.classList.remove('open');
-            });
-          }
-        });
-      }
-    });
-</script>
+<div id="nav-placeholder"></div>  <script src="/components/nav-init.js"></script>
+  <script>
+    fetch("/components/nav.html")
+      .then(function(r) { return r.text(); })
+      .then(function(html) {
+        document.getElementById("nav-placeholder").innerHTML = html;
+        initBonsaiNav();
+      });
+  </script>
 
 
   <header>

--- a/apps/tuttifruttini/about.html
+++ b/apps/tuttifruttini/about.html
@@ -20,45 +20,15 @@
 </head>
 <body>
 
-<div id="nav-placeholder"></div>
-<script>
-  fetch("/components/nav.html")
-    .then(response => response.text())
-    .then(data => {
-      document.getElementById("nav-placeholder").innerHTML = data;
-
-      // Initialize mobile submenu toggling
-      const nav = document.querySelector('.bonsai-nav');
-      if (nav) {
-        nav.addEventListener('click', function(e) {
-          if (e.target.closest('.submenu')) return;
-          const li = e.target.closest('.has-submenu');
-          if (!li) return;
-          e.preventDefault();
-          nav.querySelectorAll('.has-submenu.open').forEach(item => {
-            if (item !== li) item.classList.remove('open');
-          });
-          const isOpening = !li.classList.contains('open');
-          li.classList.toggle('open');
-          if (isOpening && window.innerWidth <= 700) {
-            const submenu = li.querySelector('.submenu');
-            if (submenu) {
-              const rect = li.getBoundingClientRect();
-              submenu.style.top = rect.bottom + 'px';
-              submenu.style.left = rect.left + 'px';
-            }
-          }
-        });
-        document.addEventListener('click', function(e) {
-          if (!e.target.closest('.bonsai-nav')) {
-            nav.querySelectorAll('.has-submenu.open').forEach(item => {
-              item.classList.remove('open');
-            });
-          }
-        });
-      }
-    });
-</script>
+<div id="nav-placeholder"></div>  <script src="/components/nav-init.js"></script>
+  <script>
+    fetch("/components/nav.html")
+      .then(function(r) { return r.text(); })
+      .then(function(html) {
+        document.getElementById("nav-placeholder").innerHTML = html;
+        initBonsaiNav();
+      });
+  </script>
 
 
   <header>

--- a/apps/wordpath/about.html
+++ b/apps/wordpath/about.html
@@ -19,48 +19,18 @@
   </style>
 </head>
 <body>
-  <div id="nav-placeholder"></div>
+  <div id="nav-placeholder"></div>  <script src="/components/nav-init.js"></script>
   <script>
     fetch("/components/nav.html")
-      .then(response => response.text())
-      .then(data => {
-        document.getElementById("nav-placeholder").innerHTML = data;
-
-        // Initialize mobile submenu toggling
-        const nav = document.querySelector('.bonsai-nav');
-        if (nav) {
-          nav.addEventListener('click', function(e) {
-            if (e.target.closest('.submenu')) return;
-            const li = e.target.closest('.has-submenu');
-            if (!li) return;
-            e.preventDefault();
-            nav.querySelectorAll('.has-submenu.open').forEach(item => {
-              if (item !== li) item.classList.remove('open');
-            });
-            const isOpening = !li.classList.contains('open');
-            li.classList.toggle('open');
-            if (isOpening && window.innerWidth <= 700) {
-              const submenu = li.querySelector('.submenu');
-              if (submenu) {
-                const rect = li.getBoundingClientRect();
-                submenu.style.top = rect.bottom + 'px';
-                submenu.style.left = rect.left + 'px';
-              }
-            }
-          });
-          document.addEventListener('click', function(e) {
-            if (!e.target.closest('.bonsai-nav')) {
-              nav.querySelectorAll('.has-submenu.open').forEach(item => {
-                item.classList.remove('open');
-              });
-            }
-          });
-        }
+      .then(function(r) { return r.text(); })
+      .then(function(html) {
+        document.getElementById("nav-placeholder").innerHTML = html;
+        initBonsaiNav();
       });
   </script>
 
   <header>
-    <h1><img src="WordPath_logo.png" alt="SonicBloom logo" style="max-width:40%; height:auto;"></h1>
+    <h1><img src="WordPath_logo.png" alt="WordPath logo" style="max-width:40%; height:auto;"></h1>
     <p><em>Grow your mind, One word at a time.</em></p>
   </header>
 

--- a/components/nav-init.js
+++ b/components/nav-init.js
@@ -1,0 +1,32 @@
+function initBonsaiNav() {
+  const nav = document.querySelector('.bonsai-nav');
+  if (!nav) return;
+
+  nav.addEventListener('click', function (e) {
+    if (e.target.closest('.submenu')) return;
+    const li = e.target.closest('.has-submenu');
+    if (!li) return;
+    e.preventDefault();
+    nav.querySelectorAll('.has-submenu.open').forEach(function (item) {
+      if (item !== li) item.classList.remove('open');
+    });
+    const isOpening = !li.classList.contains('open');
+    li.classList.toggle('open');
+    if (isOpening && window.innerWidth <= 700) {
+      const submenu = li.querySelector('.submenu');
+      if (submenu) {
+        const rect = li.getBoundingClientRect();
+        submenu.style.top = rect.bottom + 'px';
+        submenu.style.left = rect.left + 'px';
+      }
+    }
+  });
+
+  document.addEventListener('click', function (e) {
+    if (!e.target.closest('.bonsai-nav')) {
+      nav.querySelectorAll('.has-submenu.open').forEach(function (item) {
+        item.classList.remove('open');
+      });
+    }
+  });
+}

--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+  <link rel="icon" type="image/png" href="/favicon.png">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <title>Bonsai … — Pause. Reflect. Continue…</title>
 
   <style>
@@ -88,60 +89,18 @@
 <body>
 
   <!-- Bonsai Nav -->
-  <div id="nav-placeholder"></div>
-
+  <div id="nav-placeholder"></div>  <script src="/components/nav-init.js"></script>
   <script>
     fetch("/components/nav.html")
-      .then(r => r.text())
-      .then(html => {
+      .then(function(r) { return r.text(); })
+      .then(function(html) {
         document.getElementById("nav-placeholder").innerHTML = html;
-
-        // Initialize mobile submenu toggling
-        const nav = document.querySelector('.bonsai-nav');
-        if (nav) {
-          nav.addEventListener('click', function(e) {
-            // Allow submenu links to navigate normally
-            if (e.target.closest('.submenu')) return;
-
-            const li = e.target.closest('.has-submenu');
-            if (!li) return;
-
-            e.preventDefault();
-
-            // Close other open submenus
-            nav.querySelectorAll('.has-submenu.open').forEach(item => {
-              if (item !== li) item.classList.remove('open');
-            });
-
-            // Toggle current submenu
-            const isOpening = !li.classList.contains('open');
-            li.classList.toggle('open');
-
-            // Position submenu on mobile (fixed positioning)
-            if (isOpening && window.innerWidth <= 700) {
-              const submenu = li.querySelector('.submenu');
-              if (submenu) {
-                const rect = li.getBoundingClientRect();
-                submenu.style.top = rect.bottom + 'px';
-                submenu.style.left = rect.left + 'px';
-              }
-            }
-          });
-
-          // Close submenus when clicking outside
-          document.addEventListener('click', function(e) {
-            if (!e.target.closest('.bonsai-nav')) {
-              nav.querySelectorAll('.has-submenu.open').forEach(item => {
-                item.classList.remove('open');
-              });
-            }
-          });
-        }
+        initBonsaiNav();
       });
   </script>
 
   <header>
-    <img src="logo.png" class="logo">
+    <img src="logo.png" class="logo" alt="Bonsai logo">
     <p class="tagline">Pause. Reflect. Continue…</p>
 
     <div class="app-logos-section">

--- a/legal/privacy.html
+++ b/legal/privacy.html
@@ -15,43 +15,13 @@
   </style>
 </head>
 <body>
-  <div id="nav-placeholder"></div>
+  <div id="nav-placeholder"></div>  <script src="/components/nav-init.js"></script>
   <script>
     fetch("/components/nav.html")
-      .then(response => response.text())
-      .then(data => {
-        document.getElementById("nav-placeholder").innerHTML = data;
-
-        // Initialize mobile submenu toggling
-        const nav = document.querySelector('.bonsai-nav');
-        if (nav) {
-          nav.addEventListener('click', function(e) {
-            if (e.target.closest('.submenu')) return;
-            const li = e.target.closest('.has-submenu');
-            if (!li) return;
-            e.preventDefault();
-            nav.querySelectorAll('.has-submenu.open').forEach(item => {
-              if (item !== li) item.classList.remove('open');
-            });
-            const isOpening = !li.classList.contains('open');
-            li.classList.toggle('open');
-            if (isOpening && window.innerWidth <= 700) {
-              const submenu = li.querySelector('.submenu');
-              if (submenu) {
-                const rect = li.getBoundingClientRect();
-                submenu.style.top = rect.bottom + 'px';
-                submenu.style.left = rect.left + 'px';
-              }
-            }
-          });
-          document.addEventListener('click', function(e) {
-            if (!e.target.closest('.bonsai-nav')) {
-              nav.querySelectorAll('.has-submenu.open').forEach(item => {
-                item.classList.remove('open');
-              });
-            }
-          });
-        }
+      .then(function(r) { return r.text(); })
+      .then(function(html) {
+        document.getElementById("nav-placeholder").innerHTML = html;
+        initBonsaiNav();
       });
   </script>
 <header>

--- a/legal/support.html
+++ b/legal/support.html
@@ -14,48 +14,18 @@
   </style>
 </head>
 <body>
-  <div id="nav-placeholder"></div>
+  <div id="nav-placeholder"></div>  <script src="/components/nav-init.js"></script>
   <script>
     fetch("/components/nav.html")
-      .then(response => response.text())
-      .then(data => {
-        document.getElementById("nav-placeholder").innerHTML = data;
-
-        // Initialize mobile submenu toggling
-        const nav = document.querySelector('.bonsai-nav');
-        if (nav) {
-          nav.addEventListener('click', function(e) {
-            if (e.target.closest('.submenu')) return;
-            const li = e.target.closest('.has-submenu');
-            if (!li) return;
-            e.preventDefault();
-            nav.querySelectorAll('.has-submenu.open').forEach(item => {
-              if (item !== li) item.classList.remove('open');
-            });
-            const isOpening = !li.classList.contains('open');
-            li.classList.toggle('open');
-            if (isOpening && window.innerWidth <= 700) {
-              const submenu = li.querySelector('.submenu');
-              if (submenu) {
-                const rect = li.getBoundingClientRect();
-                submenu.style.top = rect.bottom + 'px';
-                submenu.style.left = rect.left + 'px';
-              }
-            }
-          });
-          document.addEventListener('click', function(e) {
-            if (!e.target.closest('.bonsai-nav')) {
-              nav.querySelectorAll('.has-submenu.open').forEach(item => {
-                item.classList.remove('open');
-              });
-            }
-          });
-        }
+      .then(function(r) { return r.text(); })
+      .then(function(html) {
+        document.getElementById("nav-placeholder").innerHTML = html;
+        initBonsaiNav();
       });
   </script>
   <header><h1>Bonsai … Support</h1></header>
   <main>
-    <p>For assistance with any Bonsai … apps, including <strong>WordPath</strong>, <strong>SonicBloom</strong>, <strong>Buy or Goodbye</strong>, <strong>CodeRain</strong>, and <strong>Tutti Fruttini Combinasion</strong> contact us at:</p>
+    <p>For assistance with any Bonsai … apps, including <strong>WordPath</strong>, <strong>SonicBloom</strong>, <strong>Buy or Goodbye</strong>, <strong>CodeRain</strong>, <strong>Ninjutsu</strong>, <strong>Scouter</strong>, and <strong>Tutti Fruttini Combinasion</strong> contact us at:</p>
     <p><a href="mailto:support@bonsaidotdot.com">support@bonsaidotdot.com</a></p>
     <p>We aim to respond within 48 hours.</p>
   </main>

--- a/legal/terms.html
+++ b/legal/terms.html
@@ -15,43 +15,13 @@
   </style>
 </head>
 <body>
-  <div id="nav-placeholder"></div>
+  <div id="nav-placeholder"></div>  <script src="/components/nav-init.js"></script>
   <script>
     fetch("/components/nav.html")
-      .then(response => response.text())
-      .then(data => {
-        document.getElementById("nav-placeholder").innerHTML = data;
-
-        // Initialize mobile submenu toggling
-        const nav = document.querySelector('.bonsai-nav');
-        if (nav) {
-          nav.addEventListener('click', function(e) {
-            if (e.target.closest('.submenu')) return;
-            const li = e.target.closest('.has-submenu');
-            if (!li) return;
-            e.preventDefault();
-            nav.querySelectorAll('.has-submenu.open').forEach(item => {
-              if (item !== li) item.classList.remove('open');
-            });
-            const isOpening = !li.classList.contains('open');
-            li.classList.toggle('open');
-            if (isOpening && window.innerWidth <= 700) {
-              const submenu = li.querySelector('.submenu');
-              if (submenu) {
-                const rect = li.getBoundingClientRect();
-                submenu.style.top = rect.bottom + 'px';
-                submenu.style.left = rect.left + 'px';
-              }
-            }
-          });
-          document.addEventListener('click', function(e) {
-            if (!e.target.closest('.bonsai-nav')) {
-              nav.querySelectorAll('.has-submenu.open').forEach(item => {
-                item.classList.remove('open');
-              });
-            }
-          });
-        }
+      .then(function(r) { return r.text(); })
+      .then(function(html) {
+        document.getElementById("nav-placeholder").innerHTML = html;
+        initBonsaiNav();
       });
   </script>
   <header><h1>Terms of Service</h1></header>


### PR DESCRIPTION
## Summary

- Fixed 4 content/markup bugs (support.html missing apps, WordPath wrong alt text, index.html missing favicons and alt text)
- Extracted duplicated nav init JS (~25 lines) to `components/nav-init.js` shared component across all 8 HTML files

## Files Changed

- `legal/support.html` — Added Ninjutsu and Scouter to app list
- `apps/wordpath/about.html` — Fixed `alt="SonicBloom logo"` → `alt="WordPath logo"`
- `index.html` — Added favicon link tags + `alt="Bonsai logo"` on logo img
- `components/nav-init.js` — New shared file with `initBonsaiNav()` function
- All 8 HTML files — Replaced inline nav script with `<script src="/components/nav-init.js"></script>`

## Test plan

- [ ] Nav menu opens/closes correctly on desktop and mobile
- [ ] Favicon appears in browser tab
- [ ] WordPath page shows correct alt text
- [ ] support.html lists all apps including Ninjutsu and Scouter

Closes #14 Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)